### PR TITLE
docs(harness): prefer GitHub MCP over gh CLI in remote sessions (#62)

### DIFF
--- a/.claude/commands/heartbeat.md
+++ b/.claude/commands/heartbeat.md
@@ -11,7 +11,7 @@ Execute **one tick** of the Polsia-style heartbeat loop as the autonomous progra
 1. **Orient (Step 1)** — read state in parallel:
    - `git status` and `git log --oneline -10`
    - `plans/main-plan.md` for current phase
-   - `gh issue list --state open --limit 20`
+   - `gh issue list --state open --limit 20` (or `mcp__github__list_issues(state: "OPEN", perPage: 30)` on remote sessions without `gh`)
    - the most recent `reports/run-*-summary.md` for continuity
    - the last ~5 entries in `decision-log.md`
    - `memory.md` for durable observations
@@ -23,7 +23,7 @@ Execute **one tick** of the Polsia-style heartbeat loop as the autonomous progra
    3. the oldest open `status:backlog` Issue, **unless** a newer Issue is a blocker or advances the core backbone while backlog is all housekeeping
    4. if plans are exhausted, summarize and stop
 
-3. **Keep backlog ≥ 3 (Step 2b)** — if fewer than 3 `status:backlog` Issues remain, decompose `plans/main-plan.md` into new Issues (use `gh issue edit --add-parent` / sub-issues where applicable, per D-20260417-018).
+3. **Keep backlog ≥ 3 (Step 2b)** — if fewer than 3 `status:backlog` Issues remain, decompose `plans/main-plan.md` into new Issues (use `gh issue edit --add-parent` / sub-issues where applicable, per D-20260417-018 — or `mcp__github__sub_issue_write` on remote sessions without `gh`).
 
 4. **Consult prior decisions (Step 3)** — search `decision-log.md` for relevant `D-YYYYMMDD-###` entries; reuse them rather than re-asking.
 
@@ -37,13 +37,13 @@ Execute **one tick** of the Polsia-style heartbeat loop as the autonomous progra
 
 9. **Commit (Step 7)** — conventional message citing the Decision ID and Issue #; never force-push, never skip hooks, never amend pushed commits.
 
-10. **Close Issue(s)** — per CLAUDE.md §6 "Run-complete ↔ Issue-close pairing": every decision-log entry marking a Run complete MUST close the corresponding GH Issue(s) via `gh issue close` with a comment citing the Decision ID + run report path.
+10. **Close Issue(s)** — per CLAUDE.md §6 "Run-complete ↔ Issue-close pairing": every decision-log entry marking a Run complete MUST close the corresponding GH Issue(s) via `gh issue close` (or `mcp__github__issue_write(method: "update", state: "closed", state_reason: "completed")` on remote sessions without `gh`) with a comment citing the Decision ID + run report path.
 
 ## Hard stops (CLAUDE.md §5 — NEVER without explicit user approval)
 Force-push · `git reset --hard` · dangerous `rm -rf` · commit secrets · skip hooks · modify `Docs/Plans/*` (except `Dev-Q&A.md`) · modify `SOUL.md` · publish to external services · close GH Issues you did not resolve · add Docker / containers / Python venvs · chat-platform messaging.
 
 ## One tick, one task
-Do not start multiple Issues in a single tick. If the chosen Issue is too large, open child sub-Issues (`gh api graphql` `addSubIssue` mutation, per D-20260417-018) and pick a leaf. Finish → close → report → commit, then end the tick.
+Do not start multiple Issues in a single tick. If the chosen Issue is too large, open child sub-Issues (`gh api graphql` `addSubIssue` mutation on local, or `mcp__github__sub_issue_write` on remote sessions without `gh`, per D-20260417-018) and pick a leaf. Finish → close → report → commit, then end the tick.
 
 ## Heartbeat ≡ both surfaces
 Per `feedback_heartbeat_rules_apply_to_loop_and_program.md` + D-20260417-021: every heartbeat convention applied here in Claude Code's `/loop` must also flow into the `heartbeat.js` product runtime. If a rule only makes sense on one side, stop and re-check.

--- a/.claude/scripts/session-prefetch.sh
+++ b/.claude/scripts/session-prefetch.sh
@@ -15,6 +15,14 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT="$REPO_ROOT/.claude/session-state.md"
 TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
+# Remote sessions don't have the `gh` CLI. Detect once and branch the Issues
+# snapshot accordingly — don't shell out to a binary that isn't there (#62).
+if command -v gh >/dev/null 2>&1; then
+  HAS_GH=1
+else
+  HAS_GH=0
+fi
+
 {
   echo "# Session Prefetch — $TS"
   echo
@@ -33,7 +41,11 @@ TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   echo
   echo "## gh issue list --state open --limit 30"
   echo '```'
-  (cd "$REPO_ROOT" && gh issue list --state open --limit 30 2>&1 | head -40)
+  if [ "$HAS_GH" = "1" ]; then
+    (cd "$REPO_ROOT" && gh issue list --state open --limit 30 2>&1 | head -40)
+  else
+    echo "_(gh CLI unavailable in this session — agent should use \`mcp__github__list_issues\` in §3 Step 1 instead.)_"
+  fi
   echo '```'
   echo
   echo "## Latest run report"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ When information conflicts, higher-priority sources win.
 | 1 | `Docs/Plans/*.md` (except `Dev-Q&A.md`) | Locked user intent | **No** |
 | 1a | [`Docs/Plans/Dev-Q&A.md`](Docs/Plans/Dev-Q&A.md) | Async design-question board — system posts, user answers, system cleans up (see §4) | **Yes** — the only writable file under `Docs/Plans/` |
 | 2 | `SOUL.md` | System identity & guardrails | **No** (without GH Issue + approval) |
-| 3 | GitHub Issues (`gh issue list`) | Active task queue | Yes — create/update/close |
+| 3 | GitHub Issues (`gh issue list` — or `mcp__github__list_issues` when the CLI is unavailable, e.g. remote heartbeat sessions) | Active task queue | Yes — create/update/close |
 | 4 | `plans/*.md` (esp. `main-plan.md`) | **Your** detailed long-term execution plans derived from #1. Work off these one small piece at a time. Refine them as you learn. | Yes |
 | 5 | `decision-log.md` | Canonical decisions; reuse before re-asking. When the user answers a `Dev-Q&A.md` question, record here before removing from Q&A. | Append-only |
 | 6 | [`architecture.md`](architecture.md), [`memory.md`](memory.md) | Living context docs | Update when workflow changes |
@@ -82,7 +82,7 @@ Execute these steps **in order**. Treat them as a checklist.
 Run in parallel where possible:
 - `git status` and `git log --oneline -10`
 - Read `plans/main-plan.md` → current phase
-- `gh issue list --state open --limit 30` (use `--limit 30`+ so new Issues aren't silently missed)
+- `gh issue list --state open --limit 30` (use `--limit 30`+ so new Issues aren't silently missed). On remote sessions without `gh`, call `mcp__github__list_issues(state: "OPEN", perPage: 30)` instead.
 - Read the most recent `reports/run-*.md` for continuity
 - Scan last 5 entries in `decision-log.md`
 - **Read [`Docs/Plans/Dev-Q&A.md`](Docs/Plans/Dev-Q&A.md)** for any user answers that arrived since the last tick — each answered question must be transcribed to `decision-log.md` as a new `D-` entry AND removed from Q&A in this heartbeat (see §4)
@@ -216,12 +216,12 @@ These are blocking. If one is needed, stop and ask.
 - **Decision IDs** — `D-YYYYMMDD-###`, required on every commit and handoff
 - **GitHub Issues = to-do list** — the user-facing task queue. Always keep at least **3 ready-to-go Issues** decomposed ahead of current work (see §3 Step 2b). Every commit references an Issue #.
 - **Run reports are mandatory** — every heartbeat that produces real work appends to `reports/run-N-summary.md`. The user has explicitly confirmed run reports are valuable. Do not skip them.
-- **Run-complete ↔ Issue-close pairing** — every `decision-log.md` entry that marks a Run as complete MUST close the corresponding GH Issue(s) in the same heartbeat (via `gh issue close` with a comment citing the Decision ID + Run report). No decision logged as "Run N complete" may coexist with an open Issue for that Run. Captured from Issue #5 (D-20260417-011).
-- **GitHub is source of truth for Issues** — update Issues only via `gh` CLI or MCP; never edit `.vscode/github-issues/*.md` directly. That folder is a one-way pull cache and local edits are discarded on next sync.
+- **Run-complete ↔ Issue-close pairing** — every `decision-log.md` entry that marks a Run as complete MUST close the corresponding GH Issue(s) in the same heartbeat (via `gh issue close` on local, or `mcp__github__issue_write(method: "update", state: "closed", state_reason: "completed")` on remote sessions without `gh`, with a comment citing the Decision ID + Run report). No decision logged as "Run N complete" may coexist with an open Issue for that Run. Captured from Issue #5 (D-20260417-011).
+- **GitHub is source of truth for Issues** — update Issues only via `gh` CLI or MCP (`mcp__github__issue_write`); never edit `.vscode/github-issues/*.md` directly. That folder is a one-way pull cache and local edits are discarded on next sync.
 - **Heartbeat pick order: oldest-first is the default, not a hard rule** — in Step 2, the default heuristic is to sort open `status:backlog` Issues by creation time ascending and pick the head. Per user directive 2026-04-17 (reaffirmed and softened 2026-04-17): oldest-first is a *recommendation*, not a requirement. Deviate when any of these apply: (a) the user explicitly redirects, (b) a newer Issue is an active blocker for older work, (c) a newer Issue directly advances the **core backbone** (DevLead MCP runtime: `heartbeat.js`, MCP orchestrator, branch/agent management) while the older queue is entirely housekeeping/meta-work — the end-goal overrides age. Always continue `status:in-progress` first. Finish before switching — spawn child Issues if scope grows, do not context-switch mid-heartbeat. Record the reason in the run report whenever you deviate from oldest-first.
 - **Async design questions via [`Docs/Plans/Dev-Q&A.md`](Docs/Plans/Dev-Q&A.md)** — per user directive 2026-04-17: *"make sure systome puts design questions in this for the project i'll answer them every now and then and that will unblock tasks. Clean it out of Q&A for tasks that have been completed already. The answer can be stored long term in the decision-log.md."* See §4b for the full read/write/clean protocol. Short form: (a) post with `Q-YYYYMMDD-###` header when a design decision blocks work but the heartbeat can keep moving elsewhere; (b) every Step 1 orient, read the file — transcribe answers to `decision-log.md` as new `D-` entries AND delete the question block; (c) also delete questions whose blocking task got done a different way or became moot (note in run report). Applies to both Claude Code and `heartbeat.js` once it can post its own questions.
 - **Multi-layer decomposition via GH sub-issues** — per user directive 2026-04-17: *"The issues need to be taken care of broken down into small tasks if they're large using the child task feature … I don't care how many layers there has to be in order to do this properly but it needs to be smart about it."* Rules:
-  1. **If an Issue is too big for one heartbeat, decompose it into sub-issues using GitHub's native child-issue feature**, not just text references. Create children via `gh api graphql` with the `addSubIssue` mutation (or `gh issue edit --add-sub-issue` once that flag ships). Each child is a standalone atomic Issue with its own AC and labels; the parent tracks the relationship.
+  1. **If an Issue is too big for one heartbeat, decompose it into sub-issues using GitHub's native child-issue feature**, not just text references. Create children via `gh api graphql` with the `addSubIssue` mutation (or `gh issue edit --add-sub-issue` once that flag ships). On remote sessions without `gh`, use `mcp__github__sub_issue_write` instead. Each child is a standalone atomic Issue with its own AC and labels; the parent tracks the relationship.
   2. **Children must close before their parent closes.** When picking work (§3 Step 2), prefer an open *leaf* (no open children) before picking any Issue with open children — the parent is not ready.
   3. **Nesting depth is unbounded.** Go as deep as the problem requires. If a child is still too big, break it into grandchildren. Each layer must still satisfy the atomic-per-heartbeat rule.
   4. **Be smart about it.** Do not decompose trivially; aim for the smallest decomposition that makes each leaf finishable in one heartbeat. If a decomposition produces >6 siblings, it is likely too flat — group related children under an intermediate sub-epic instead.
@@ -237,7 +237,7 @@ This file + the plans under `Docs/Plans/` are the authoritative workflow guidanc
 
 ## 7. Tools You Have Available
 
-- **Native**: `Read`, `Edit`, `Write`, `Grep`, `Glob`, `Bash` (node, npm, git, `gh`)
+- **Native**: `Read`, `Edit`, `Write`, `Grep`, `Glob`, `Bash` (node, npm, git, `gh` when available — remote heartbeat sessions lack `gh` and must use the GitHub MCP tools below)
 - **Subagents**: `Agent` tool — use `Explore` for codebase search, `general-purpose` for multi-step tasks, specialized agents (code-reviewer, plugin-validator, etc.) when they fit
 - **Project MCP servers** (configured in [`.mcp.json`](.mcp.json); activate after Claude Code restarts):
   - `mempalace` — **authoritative project memory** (Wings → Halls → Rooms) backed by `C:/Users/weird/.GitHub/mempalace/palace`. Use for all durable cross-run observations (this overrides the generic `memory` MCP for project-specific knowledge). Tools: `mempalace_search`, `mempalace_kg_query`, `mempalace_diary_write`, `mempalace_add_drawer`, etc.


### PR DESCRIPTION
Closes #62 per D-20260419-001.

## Summary
Remote heartbeat sessions (this one included) lack the `gh` CLI. Until this change every `gh issue list` / `gh issue close` / `gh api graphql` reference in our docs was a dead letter on remote, and `.claude/scripts/session-prefetch.sh` silently wrote a `gh: command not found` error into `.claude/session-state.md` instead of a real Issues snapshot.

## What changed
- **`.claude/scripts/session-prefetch.sh`** — detect `gh` once at the top with `command -v gh`. When absent, write a short note (*"gh CLI unavailable in this session — agent should use `mcp__github__list_issues` in §3 Step 1 instead."*) into the `## gh issue list ...` section instead of shelling out to the missing binary. When present, behavior is unchanged.
- **`CLAUDE.md`** §2 / §3 Step 1 / §6 / §7 — every `gh` command now names its MCP equivalent in parentheses:
  - `gh issue list` → `mcp__github__list_issues(state: "OPEN", perPage: 30)`
  - `gh issue close` → `mcp__github__issue_write(method: "update", state: "closed", state_reason: "completed")`
  - `gh api graphql` `addSubIssue` → `mcp__github__sub_issue_write`
  - §7 Tools line now flags that remote sessions lack `gh` and must use the GitHub MCP tools.
- **`.claude/commands/heartbeat.md`** — same dual-path treatment on Orient (Step 1), backlog refill (Step 2b), Issue-close (Step 10), and one-tick decomposition footer.

## AC (Issue #62)
- [x] `session-prefetch.sh` no longer errors on missing `gh`; prints a note instead.
- [x] `CLAUDE.md` + `.claude/commands/heartbeat.md` name the MCP equivalents next to each `gh` command.
- [x] A fresh remote session run through the full pipeline succeeds end-to-end without `gh` — **this PR was authored on one**. `gh` is absent (`command -v gh` → exit 1), orient used `mcp__github__list_issues`, PR is being opened via `mcp__github__create_pull_request`, root `npm test` → 24/24 pass.

## Test plan
- [x] `bash .claude/scripts/session-prefetch.sh` exits 0 on a host without `gh`; `## gh issue list ...` section contains the friendly redirect note.
- [x] `npm test` → 24/24 pass on the branch (no code logic changed; sanity check for accidental regressions).
- [x] `grep -n "gh " CLAUDE.md .claude/commands/heartbeat.md` shows every `gh` command paired with an `mcp__github__*` equivalent.
- [ ] On merge: next remote heartbeat session writes the friendly MCP note in `session-state.md` instead of `gh: command not found`.

D-20260419-001