### PR TITLE
feat(dashboard): Issue #152 inspector polish (focus + copy feedback) + #155 @testing-library/dom

### DIFF
--- a/dashboard/__tests__/coding-tab.test.tsx
+++ b/dashboard/__tests__/coding-tab.test.tsx
@@ -404,3 +404,150 @@ describe('Issue #150 §D.3.b — Inspector panel', () => {
         expect(onMessageClick).toHaveBeenCalledWith('btn', thread.messages[0]);
     });
 });
+
+describe('Issue #152 §D.3.b polish — focus + copy feedback + null-selection', () => {
+    afterEach(cleanup);
+
+    // 21 — AC 1a: close button receives focus on mount.
+    it('InspectorPanel moves focus to the close button on mount', () => {
+        const message: HandoffMessage = {
+            timestamp: '2026-04-19T10:00:00Z',
+            from: 'claude',
+            to: 'roo',
+            text: 'focus-on-mount',
+        };
+        render(<InspectorPanel message={message} threadId="t-1" onClose={() => {}} />);
+        const closeBtn = screen.getByLabelText(/close inspector/i);
+        expect(document.activeElement).toBe(closeBtn);
+    });
+
+    // 22 — AC 1b: focus returns to the previously-active trigger element on unmount.
+    it('InspectorPanel restores focus to the previously-active element on unmount', () => {
+        const message: HandoffMessage = {
+            timestamp: '2026-04-19T10:00:00Z',
+            from: 'claude',
+            to: 'roo',
+            text: 'focus-restore',
+        };
+        const trigger = document.createElement('button');
+        trigger.textContent = 'trigger';
+        document.body.appendChild(trigger);
+        trigger.focus();
+        expect(document.activeElement).toBe(trigger);
+        try {
+            const { unmount } = render(
+                <InspectorPanel message={message} threadId="t-1" onClose={() => {}} />,
+            );
+            // Panel stole focus from the trigger.
+            expect(document.activeElement).not.toBe(trigger);
+            unmount();
+            // Panel restored it on the way out.
+            expect(document.activeElement).toBe(trigger);
+        } finally {
+            document.body.removeChild(trigger);
+        }
+    });
+
+    // 23 — AC 2a: "Copied" confirmation appears after a successful clipboard write.
+    it('InspectorPanel shows "Copied" confirmation after a successful clipboard write', async () => {
+        const message: HandoffMessage = {
+            timestamp: '2026-04-19T10:00:00Z',
+            from: 'claude',
+            to: 'roo',
+            text: 'copy-ok',
+        };
+        const writeText = jest.fn().mockResolvedValue(undefined);
+        const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { writeText },
+            configurable: true,
+        });
+        try {
+            render(
+                <InspectorPanel message={message} threadId="t-1" onClose={() => {}} />,
+            );
+            fireEvent.click(screen.getByRole('button', { name: /copy json/i }));
+            await screen.findByText(/copied/i);
+        } finally {
+            if (originalClipboard) {
+                Object.defineProperty(navigator, 'clipboard', originalClipboard);
+            } else {
+                Object.defineProperty(navigator, 'clipboard', {
+                    value: undefined,
+                    configurable: true,
+                });
+            }
+        }
+    });
+
+    // 24 — AC 2b: "Copy failed" appears when the clipboard API is unavailable.
+    it('InspectorPanel shows "Copy failed" when navigator.clipboard is unavailable', async () => {
+        const message: HandoffMessage = {
+            timestamp: '2026-04-19T10:00:00Z',
+            from: 'claude',
+            to: 'roo',
+            text: 'copy-missing',
+        };
+        const originalClipboard = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+        Object.defineProperty(navigator, 'clipboard', {
+            value: undefined,
+            configurable: true,
+        });
+        try {
+            render(
+                <InspectorPanel message={message} threadId="t-1" onClose={() => {}} />,
+            );
+            fireEvent.click(screen.getByRole('button', { name: /copy json/i }));
+            await screen.findByText(/copy failed/i);
+        } finally {
+            if (originalClipboard) {
+                Object.defineProperty(navigator, 'clipboard', originalClipboard);
+            }
+        }
+    });
+
+    // 25 — AC 3a: explicit selectedMessage={null} must NOT render the inspector.
+    //        Locks the "null is a valid controlled no-selection" semantic so a
+    //        refactor to `!!selectedMessage` would fail loud.
+    it('CodingTabContent treats explicit selectedMessage={null} as no-selection', () => {
+        const thread = makeThread({
+            id: 'nullsel',
+            messages: [
+                {
+                    timestamp: '2026-04-19T10:00:00Z',
+                    from: 'claude',
+                    to: 'roo',
+                    text: 'nope',
+                },
+            ],
+        });
+        render(<CodingTabContent threads={[thread]} selectedMessage={null} />);
+        expect(screen.queryByLabelText(/close inspector/i)).not.toBeInTheDocument();
+    });
+
+    // 26 — AC 3b: flipping selectedMessage from null to a concrete value mounts the inspector.
+    it('CodingTabContent mounts the inspector when selectedMessage flips from null to a value', () => {
+        const thread = makeThread({
+            id: 'flip',
+            messages: [
+                {
+                    timestamp: '2026-04-19T10:00:00Z',
+                    from: 'claude',
+                    to: 'roo',
+                    text: 'flip-me',
+                },
+            ],
+        });
+        const { rerender } = render(
+            <CodingTabContent threads={[thread]} selectedMessage={null} />,
+        );
+        expect(screen.queryByLabelText(/close inspector/i)).not.toBeInTheDocument();
+        rerender(
+            <CodingTabContent
+                threads={[thread]}
+                selectedMessage={{ threadId: 'flip', message: thread.messages[0] }}
+            />,
+        );
+        expect(screen.getByLabelText(/close inspector/i)).toBeInTheDocument();
+    });
+});

--- a/dashboard/app/_components/coding/InspectorPanel.tsx
+++ b/dashboard/app/_components/coding/InspectorPanel.tsx
@@ -1,25 +1,26 @@
 'use client';
 
 import type { ReactElement } from 'react';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { HandoffMessage } from './types';
 
 /**
- * Issue #150 / Phase 3 §D.3.b — Coding-tab inspector panel (skeleton).
+ * Issue #150 / Phase 3 §D.3.b — Coding-tab inspector panel.
+ * Issue #152 polish — dialog focus management + copy feedback.
  *
  * Fixed-width (w-80 = 320 px) right-side panel rendered next to the thread
- * list when a `HandoffMessage` is selected. V1 is deliberately a skeleton:
+ * list when a `HandoffMessage` is selected.
  *   - Body: pretty-printed JSON via `<pre>{JSON.stringify(...)}</pre>`.
- *     A tree widget / diff view / VS Code jump-links are explicitly deferred
- *     to later leaves.
- *   - Footer: a "Copy JSON" button that writes the pretty-printed JSON to
- *     the clipboard via `navigator.clipboard.writeText`. When the clipboard
- *     API is unavailable (older browsers, jsdom without polyfill), the click
- *     is a graceful no-op — never throws.
- *   - Escape key closes the inspector (document-level listener, cleaned up
- *     on unmount so we don't swallow Escape when nothing is inspected).
- *   - Empty-payload guard: when `message.text` is an empty string, the body
- *     renders "No payload" instead of serializing a near-empty struct.
+ *   - Footer: "Copy JSON" button with inline "Copied" / "Copy failed" feedback
+ *     that returns to idle after 2 s. Copy still no-ops gracefully when the
+ *     clipboard API is unavailable — but the UI now tells the user so the
+ *     click is never silent.
+ *   - Escape key closes the inspector.
+ *   - Empty-payload guard: renders "No payload" when message.text is "".
+ *   - Focus management (#152): on mount, keyboard focus moves to the close
+ *     button; on unmount, focus returns to whatever element was active at
+ *     mount time (the trigger in HandoffThread). Self-contained — no parent
+ *     wiring needed.
  */
 
 interface InspectorPanelProps {
@@ -28,33 +29,35 @@ interface InspectorPanelProps {
     onClose: () => void;
 }
 
-function copyToClipboard(text: string): void {
-    // Guard on both `navigator` (SSR safety) and `navigator.clipboard`
-    // (older browsers / test env without polyfill). Any rejection from the
-    // underlying writeText promise is swallowed so a transient clipboard
-    // denial can't crash the UI.
-    if (typeof navigator === 'undefined') return;
-    const clipboard = navigator.clipboard as
-        | { writeText?: (s: string) => Promise<void> | void }
-        | undefined;
-    if (!clipboard || typeof clipboard.writeText !== 'function') return;
-    try {
-        const result = clipboard.writeText(text);
-        if (result && typeof (result as Promise<void>).catch === 'function') {
-            (result as Promise<void>).catch(() => {
-                /* graceful no-op on permission / transient failures */
-            });
-        }
-    } catch {
-        /* graceful no-op */
-    }
-}
+type CopyStatus = 'idle' | 'copied' | 'failed';
+const COPY_FLASH_MS = 2000;
 
 export function InspectorPanel({
     message,
     threadId,
     onClose,
 }: InspectorPanelProps): ReactElement {
+    const closeBtnRef = useRef<HTMLButtonElement>(null);
+    const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+
+    // Focus management: on mount capture the currently-active element, move
+    // focus to the close button, and on unmount return focus to the captured
+    // element. This keeps keyboard-only users anchored to their trigger after
+    // they dismiss the dialog.
+    useEffect(() => {
+        const previousActive =
+            typeof document !== 'undefined'
+                ? (document.activeElement as HTMLElement | null)
+                : null;
+        closeBtnRef.current?.focus();
+        return () => {
+            if (previousActive && typeof previousActive.focus === 'function') {
+                previousActive.focus();
+            }
+        };
+    }, []);
+
     // Escape closes. Document-level listener only exists while mounted so we
     // don't steal Escape from other components when the inspector is hidden.
     useEffect(() => {
@@ -65,17 +68,60 @@ export function InspectorPanel({
         return () => document.removeEventListener('keydown', onKeyDown);
     }, [onClose]);
 
+    // Clear any pending flash-reset on unmount so we don't call setState
+    // after the component is gone.
+    useEffect(() => {
+        return () => {
+            if (copyResetRef.current !== null) {
+                clearTimeout(copyResetRef.current);
+                copyResetRef.current = null;
+            }
+        };
+    }, []);
+
     const hasPayload = message.text !== '';
     const prettyJson = hasPayload ? JSON.stringify(message, null, 2) : '';
 
+    const flashStatus = useCallback((status: 'copied' | 'failed') => {
+        setCopyStatus(status);
+        if (copyResetRef.current !== null) clearTimeout(copyResetRef.current);
+        copyResetRef.current = setTimeout(() => {
+            setCopyStatus('idle');
+            copyResetRef.current = null;
+        }, COPY_FLASH_MS);
+    }, []);
+
     const handleCopy = useCallback(() => {
         if (!hasPayload) return;
-        copyToClipboard(prettyJson);
-    }, [hasPayload, prettyJson]);
+        if (typeof navigator === 'undefined') {
+            flashStatus('failed');
+            return;
+        }
+        const clipboard = navigator.clipboard as
+            | { writeText?: (s: string) => Promise<void> | void }
+            | undefined;
+        if (!clipboard || typeof clipboard.writeText !== 'function') {
+            flashStatus('failed');
+            return;
+        }
+        try {
+            const result = clipboard.writeText(prettyJson);
+            if (
+                result &&
+                typeof (result as Promise<void>).then === 'function'
+            ) {
+                (result as Promise<void>).then(
+                    () => flashStatus('copied'),
+                    () => flashStatus('failed'),
+                );
+            } else {
+                flashStatus('copied');
+            }
+        } catch {
+            flashStatus('failed');
+        }
+    }, [hasPayload, prettyJson, flashStatus]);
 
-    // Header title: use the first ~80 chars of the message text as a summary.
-    // (The parent passes the selection context via threadId for later leaves
-    // that will surface "Thread: foo → bar" etc.; for now we keep it simple.)
     const headerTitle = hasPayload
         ? truncate(message.text, 80)
         : `(empty message from ${message.from})`;
@@ -97,6 +143,7 @@ export function InspectorPanel({
                     {headerTitle}
                 </h3>
                 <button
+                    ref={closeBtnRef}
                     type="button"
                     onClick={onClose}
                     aria-label="Close inspector"
@@ -122,7 +169,21 @@ export function InspectorPanel({
                 )}
             </div>
 
-            <footer className="border-t border-gray-800 px-3 py-2 flex justify-end">
+            <footer className="border-t border-gray-800 px-3 py-2 flex items-center justify-end gap-2">
+                {copyStatus !== 'idle' ? (
+                    <span
+                        role="status"
+                        aria-live="polite"
+                        data-testid="inspector-copy-status"
+                        className={
+                            copyStatus === 'copied'
+                                ? 'text-xs text-emerald-400'
+                                : 'text-xs text-red-400'
+                        }
+                    >
+                        {copyStatus === 'copied' ? 'Copied ✓' : 'Copy failed'}
+                    </span>
+                ) : null}
                 <button
                     type="button"
                     onClick={handleCopy}

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -18,6 +18,7 @@
         "zustand": "^5.0.12"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
@@ -138,7 +139,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -735,7 +735,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -784,7 +783,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2629,9 +2627,8 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2642,7 +2639,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2723,7 +2719,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -3243,7 +3238,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3837,7 +3831,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4379,7 +4372,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4403,7 +4395,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4419,7 +4410,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4933,7 +4924,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5103,7 +5093,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6760,7 +6749,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -7651,7 +7639,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7682,7 +7669,6 @@
       "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.5",
         "@asamuzakjp/dom-selector": "^7.0.6",
@@ -8664,7 +8650,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8791,7 +8776,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9067,7 +9051,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9077,7 +9060,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10578,7 +10560,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -29,6 +29,7 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary

Delivers Issue #152 (§D.3.b inspector polish — the 3 code-quality NITs consolidated from Issue #150's review) and #155 (blocking `@testing-library/dom` devDep regression surfaced mid-flight).

Per **D-20260420-001** (Run 35).

## Issue #152 — inspector polish

| AC | Status | Where |
|---|---|---|
| 1a. Close button receives keyboard focus on mount | ✅ | `InspectorPanel.tsx` — `closeBtnRef` + `useEffect(..., [])`  |
| 1b. Focus restored to the trigger element on unmount | ✅ | Same effect captures `document.activeElement` at mount, restores in cleanup |
| 2a. "Copied ✓" appears after successful clipboard write | ✅ | `copyStatus` state + `flashStatus('copied')` |
| 2b. "Copy failed" appears when clipboard API unavailable | ✅ | `flashStatus('failed')` on both missing-API and Promise rejection paths |
| 2c. Flash returns to idle after ~2 s | ✅ | `setTimeout(COPY_FLASH_MS = 2000)`; timer cleared on unmount to avoid setState-after-unmount |
| 3a. `selectedMessage={null}` explicit controlled value → inspector NOT rendered | ✅ | Existing semantic preserved; locked by new test |
| 3b. Flipping `selectedMessage` from `null` to a value → inspector mounts | ✅ | Locked by new test |

### Design notes

- **Focus management is self-contained** per the Issue's own recommendation — `InspectorPanel` stores `document.activeElement` at mount and restores it on unmount. No parent wiring needed in `CodingTabContent`.
- **Copy feedback uses `role="status" aria-live="polite"`** so a screen reader announces the result without interrupting the user.
- **Pending flash-timer cleared on unmount** (separate cleanup effect) to prevent `setState` after the component is gone when the user closes the inspector mid-flash.

## Issue #155 — fixed inline (blocked #152's verification)

`npm test` on this session's fresh install failed 8/13 suites with `Cannot find module '@testing-library/dom'`. Root cause: `@testing-library/react@16+` declares `@testing-library/dom` as a **peer** dep, and npm 10+ prunes un-owned peers on fresh installs. Filed as #155; fixed in the same commit since #152's AC requires `npm test` green.

```diff
   "devDependencies": {
     ...
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
```

## Test evidence

- **Red run** (pre-implementation, after new tests added): `Tests: 4 failed, 23 passed, 27 total` — tests 21 (focus-on-mount), 22 (focus-restore), 23 (Copied), 24 (Copy failed). Tests 25–26 already green (existing `CodingTabContent` handled `null` correctly — the 2 tests are regression locks).
- **Green run** (post-implementation): `Tests: 27 passed, 27 total` for `coding-tab`; `Tests: 154 passed, 154 total` suite-wide (148 baseline + 6 new).
- `npm run build` → `Next.js 15.5.15` compiled successfully; `Generating static pages (4/4)` ✓.
- `npm run check:types` → clean.
- `node scripts/check-arch.js` → `3/3 PASS`.

## Decision ID

`D-20260420-001` (Run 35).

## Closes

- Closes #152
- Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)