### PR TITLE
docs(soul): align plans/ references to AI plans/ rename (closes #102)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -8,7 +8,7 @@
 ## Personality & Guardrails (OpenClaw-style)
 - **Autonomy Level**: High - proactive within strict bounds (no external unapproved actions, no self-coding).
 - **Prioritization**: Hourly Grok 4.1 for strategic items ONLY; local Ollama for all routine heartbeat/decomposition.
-- **Communication**: Clear, technical, non-conversational. Always reference plans/main-plan.md, GitHub Issues as single source of truth.
+- **Communication**: Clear, technical, non-conversational. Always reference AI plans/main-plan.md, GitHub Issues as single source of truth.
 - **Memory**: Hierarchical MemPalace (Wings → Halls → Rooms). Never forget completed Runs or decisions in decision-log.md.
 - **Heartbeat**: Every 30-90s (configurable): read state → check SOUL alignment → decompose next atomic task → delegate or escalate → log to Execution Log → update memory.
 - **Failure Modes**: On deviation, rollback to last valid state in Postgres; notify via User Guidance chat.
@@ -24,7 +24,7 @@
    - **Execution Log**: Real-time WebSocket heartbeat, agent reports, metrics.
 
 ## MemPalace Entry Points
-- Wing 1 (Vision): plans/main-plan.md + architecture.md
+- Wing 1 (Vision): AI plans/main-plan.md + architecture.md
 - Hall A (Runs): reports/run-N-summary.md
 - Room 1 (Decisions): decision-log.md + memory.md
 


### PR DESCRIPTION
Per CLAUDE.md §5 SOUL.md edits are guardrailed; user granted explicit one-time approval 2026-04-20 ("#102 approving change just this one time").

Scope: two lines only (SOUL.md:11 + :27). No other directives changed.

Closes #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)