### PR TITLE
docs(claude): correct SOUL.md path-history note + cite Issue #181

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ $PLANS_VAULT_PATH/AI plans/*.md    (YOUR detailed long-term execution plans;
 
 **Key mindset**: `AI plans/` (in the vault) is where you think big and write it down once. GitHub Issues is where you pick off one small piece at a time. If a plan in `AI plans/` is too fuzzy to produce the next 3 Issues, refine the plan first — then decompose.
 
-> **Path history**: the repo folder `plans/` was renamed to `AI plans/` (2026-04-18), then both `Docs/Plans/` and `AI plans/` were moved to the Obsidian vault (2026-04-25, WEI-71/WEI-72). **Pending**: `SOUL.md` still references `plans/main-plan.md` on lines 11 + 27 — SOUL.md cannot be edited without explicit user approval per §5 (tracked by a follow-up sub-issue). Historical `reports/run-*.md` and earlier `decision-log.md` entries retain old in-repo paths for provenance — not rewriting history.
+> **Path history**: the repo folder `plans/` was renamed to `AI plans/` (2026-04-18), then both `Docs/Plans/` and `AI plans/` were moved to the Obsidian vault (2026-04-25, WEI-71/WEI-72). **Pending**: `SOUL.md` still references `AI plans/main-plan.md` (without the vault prefix) on lines 11 + 27 — SOUL.md cannot be edited without explicit user approval per §5 (tracked by Issue #181). Historical `reports/run-*.md` and earlier `decision-log.md` entries retain old in-repo paths for provenance — not rewriting history.
 
 Project identity and guardrails are in [`SOUL.md`](SOUL.md). The SOUL is immutable for Phase 1 — any change requires a GitHub Issue and explicit user approval.
 


### PR DESCRIPTION
## Summary

Two small fixes to the WEI-71 path-history paragraph in CLAUDE.md §1:

1. SOUL.md actually references `AI plans/main-plan.md` (the pre-vault form), not `plans/main-plan.md` as the prior text claimed. The pre-vault rename happened 2026-04-18; SOUL.md was updated then but never picked up the vault prefix during WEI-71.
2. Replace the generic "follow-up sub-issue" pointer with the concrete Issue #181 that Isaac just opened to track the SOUL.md vault-path update (still blocked on explicit user approval per CLAUDE.md §5).

No behavior change. Pure docs accuracy fix.

## Why now

PR #180 merged the WEI-71 migration with these two stale fragments. Caught immediately on the next heartbeat orient. Fixing in a tiny follow-up rather than rolling into a future PR keeps the trail traceable.

## Test plan

- [x] `git diff` is single line, +1/-1
- [x] No code changes; nothing to test beyond the diff itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)