### PR TITLE
WEI-1287: expand DevLead route title fallback coverage

### DIFF
--- a/tests/devlead-route.test.js
+++ b/tests/devlead-route.test.js
@@ -45,6 +45,17 @@ test('title-encoded area:ui classifies when labels[] empty', () => {
   assert.equal(r.specialist, 'Coder-Frontend');
 });
 
+test('title-encoded area:backend classifies when labels[] empty', () => {
+  const r = classify({ labels: [], title: 'area:backend — MCP route cleanup' });
+  assert.equal(r.specialist, 'Coder-Backend');
+});
+
+test('title-encoded type:bug keeps regression-test priority when labels[] empty', () => {
+  const r = classify({ labels: [], title: 'type:bug area:backend — heartbeat crash' });
+  assert.equal(r.specialist, 'Tester');
+  assert.match(r.reason, /regression test/);
+});
+
 test('description prose alone does NOT classify (avoids self-match on docs)', () => {
   // An issue that describes the routing table in its body must not classify itself.
   const r = classify({ labels: [], title: 'L9: orchestrator routing', description: 'Mapping: area:ui -> Coder-Frontend; type:bug -> Tester' });


### PR DESCRIPTION
## Summary

- Adds test coverage for title-encoded `area:backend` routing when Paperclip labels are absent.
- Adds test coverage that title-encoded `type:bug` still routes to Tester first, preserving regression-test priority over backend work.

## Evidence

- Specialist-authored PR for [WEI-650](/WEI/issues/WEI-650) autonomous merge proof under Decision `D-20260517-003`.
- Source issue: [WEI-1287](/WEI/issues/WEI-1287).
- Base branch: `main`.
- Head branch: `feature/WEI-1287-autonomous-merge-proof`.

## Verification

- `node --test tests/devlead-route.test.js` -> 13/13 pass.
- `node scripts/devlead-route.js --self-test` -> 9/9 pass.

## Gate notes

- CI/check evidence: requested from GitHub checks on this PR.
- Coverage impact: test-only change for existing route classifier behavior.
- Security impact: no runtime or dependency change; security gate can treat this as test-only unless policy requires an explicit scan.